### PR TITLE
137-python39-support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "~3.9 | ~3.10 | ~3.11 | ~3.12"
 numpy = "^1.24"
 nibabel = "^5.0.1"
 matplotlib = "^3.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Pyneapple"
-version = "1.1.0"
+version = "1.1.1"
 description = "Pyneapple is an advanced tool for analysing multi-exponential signal data in MR DWI images."
 authors = ["Thomas Thiel <thomas.thiel@hhu.de>", "Jonas Jasse, <jonas.jasse@hhu.de>"]
 maintainers = ["Jonas Jasse <jonas.jasse@hhu.de>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ pytest = "^8.1.1"
 pytest-order = "^1.2.1"
 pytest-qt = "^4.4.0"
 openpyxl = "^3.1.2"
+tox = "4.20.0"
 
 [tool.poetry.group.ui]
 optional = true

--- a/src/pyneapple/fit/IDEAL.py
+++ b/src/pyneapple/fit/IDEAL.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 from .parameters import Params, IDEALParams

--- a/src/pyneapple/fit/NNLS_reg_CV.py
+++ b/src/pyneapple/fit/NNLS_reg_CV.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from scipy.optimize import nnls
 from scipy.linalg import norm

--- a/src/pyneapple/fit/boundaries.py
+++ b/src/pyneapple/fit/boundaries.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from abc import ABC, abstractmethod
 import numpy as np
 

--- a/src/pyneapple/fit/fit.py
+++ b/src/pyneapple/fit/fit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 import time
 

--- a/src/pyneapple/fit/model.py
+++ b/src/pyneapple/fit/model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import time
 

--- a/src/pyneapple/ui/appdata.py
+++ b/src/pyneapple/ui/appdata.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 from ..utils.nifti import Nii, NiiSeg

--- a/src/pyneapple/ui/canvas_plot.py
+++ b/src/pyneapple/ui/canvas_plot.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PyQt6 import QtWidgets
 import numpy as np
 

--- a/src/pyneapple/ui/dlg_settings.py
+++ b/src/pyneapple/ui/dlg_settings.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from PyQt6 import QtWidgets, QtCore, QtGui
 from pathlib import Path
 from os import cpu_count

--- a/src/pyneapple/ui/pyneapple_ui.py
+++ b/src/pyneapple/ui/pyneapple_ui.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import sys
 

--- a/src/pyneapple/ui/widgets_fitting.py
+++ b/src/pyneapple/ui/widgets_fitting.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Callable
 from PyQt6 import QtWidgets, QtCore
 import numpy as np

--- a/src/pyneapple/utils/multithreading.py
+++ b/src/pyneapple/utils/multithreading.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import numpy as np
 
 from typing import Callable
@@ -69,7 +70,7 @@ def sort_interpolated_array(results: list, array: np.ndarray) -> np.ndarray:
         array: With sorted results.
     """
     for element in results:
-        array[:, :, *element[0]] = element[1]
+        array[:, :, tuple(element[0])] = element[1]  # python 3.9 support
     return array
 
 

--- a/src/pyneapple/utils/plotting.py
+++ b/src/pyneapple/utils/plotting.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.axis as plt_axis
@@ -32,9 +33,7 @@ def show_pixel_fit(axis: plt_axis, canvas: FigureCanvas, data: AppData, pos: lis
     number_slice = data.plt["n_slice"].value
     color = plt.rcParams["axes.prop_cycle"].by_key()["color"][0]
     # pixel_result = data.fit_data.fit_results.raw.get((pos[0], pos[1], number_slice), None)
-    pixel_result = data.fit_data.results.curve.get(
-        (pos[0], pos[1], number_slice), None
-    )
+    pixel_result = data.fit_data.results.curve.get((pos[0], pos[1], number_slice), None)
     if pixel_result is not None:
         # get Y data
         y_data = np.squeeze(pixel_result)

--- a/src/pyneapple/utils/processing.py
+++ b/src/pyneapple/utils/processing.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import numpy as np
 import warnings
 from .nifti import Nii, NiiSeg

--- a/tests/test_ivim_parameters.py
+++ b/tests/test_ivim_parameters.py
@@ -141,8 +141,8 @@ class TestIVIMSegmentedParameters:
         fixed_values = [adc, t1]
         pixel_args = params.get_pixel_args(img, seg, *fixed_values)
         for arg in pixel_args:
-            assert arg[2] == fixed_values[0][*arg[0]]
-            assert arg[3] == fixed_values[1][*arg[0]]
+            assert arg[2] == fixed_values[0][tuple(arg[0])]  # python 3.9 support
+            assert arg[3] == fixed_values[1][tuple(arg[0])]
 
     def test_eval_fitting_results_bi_exp(
         self, ivim_bi_params_file, results_bi_exp, fixed_values

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py39, py310, py311, py312
+
+[testenv]
+deps = pytest
+commands = pytest


### PR DESCRIPTION
Added py39 Support. Type annotations have 3.10 style and are imported by "future". Asterisk subscription is handled by casting tuple on lists.