### PR TITLE
205 implement fitresult dataclass for unified solver diagnostics

### DIFF
--- a/.github/pyneapple_fitter_plugin.md
+++ b/.github/pyneapple_fitter_plugin.md
@@ -64,7 +64,7 @@ class BaseFitter(ABC):
 
 ### FitResult — the public result object
 
-`_assemble_fit_result()` reads `self.solver.pixel_results_` and builds a `FitResult`:
+`_assemble_fit_result()` delegates to ``self.solver.result_`` (a partial :class:`~pyneapple.result.FitResult` assembled by the solver from its ``pixel_results_``) and overlays the fitter-specific fields (``r_squared``, ``fit_time``, ``image_shape``, ``pixel_indices``):
 
 ```python
 from pyneapple.result import FitResult
@@ -255,6 +255,7 @@ Fitters receive a solver instance. Key attributes/methods:
 - `solver.params_ -> dict[str, Any]` — fitted parameters (populated after `fit()`)
 - `solver.diagnostics_ -> dict[str, Any]` — fit diagnostics (populated after `fit()`)
 - `solver.pixel_results_ -> list[_PixelFitResult]` — per-pixel typed results consumed by `_assemble_fit_result()`
+- `solver.result_ -> FitResult | None` — partial `FitResult` assembled from `pixel_results_` (``None`` before ``fit()``); consumed by `_assemble_fit_result()`
 
 ## Pyneapple model interface (read-only — do not reimplement)
 

--- a/.github/pyneapple_solver_plugin.md
+++ b/.github/pyneapple_solver_plugin.md
@@ -24,11 +24,13 @@ Every solver **must**:
    - Return `self`
 5. Implement `_fit_single_pixel()` to return a `_PixelFitResult` (see below)
 6. After fitting all pixels, store the list of per-pixel results in `self.pixel_results_`
+7. After `fit()` returns, consumers can access a partial :class:`~pyneapple.result.FitResult` via the :attr:`result_` property (assembled automatically from ``pixel_results_``)
 
 ### BaseSolver interface
 
 ```python
 from pyneapple.solvers.base import BaseSolver, _PixelFitResult
+from pyneapple.result import FitResult
 
 class BaseSolver(ABC):
     def __init__(self, model, max_iter=250, tol=1e-8, verbose=False, **solver_kwargs):
@@ -46,6 +48,19 @@ class BaseSolver(ABC):
     def get_diagnostics(self) -> dict[str, Any]: ...  # raises RuntimeError if empty
     def get_params(self) -> dict[str, Any]: ...        # raises RuntimeError if empty
     def _reset_state(self): ...                        # clears params_, diagnostics_, pixel_results_
+
+    @property
+    def result_(self) -> FitResult | None:
+        """Partial FitResult assembled from ``pixel_results_``.
+        ``None`` before :meth:`fit` is called.
+        """
+        ...
+
+    def _build_result(self) -> FitResult:
+        """Assemble a partial FitResult from the current ``pixel_results_``.
+        Called automatically by :attr:`result_` on every access.
+        """
+        ...
 ```
 
 ### _PixelFitResult dataclass

--- a/src/pyneapple/cli/_common.py
+++ b/src/pyneapple/cli/_common.py
@@ -17,6 +17,7 @@ from ..io import (
     save_parameter_map,
     reconstruct_maps,
     reconstruct_segmentation_maps,
+    save_result_to_hdf5,
 )
 from ..io.toml import load_config
 
@@ -43,6 +44,13 @@ def shared_options(f):
                      )),
         click.option("--verbose", "-v", is_flag=True, default=False,
                      help="Enable DEBUG-level logging."),
+        click.option("--diagnostics", "-d", is_flag=True, default=False,
+                     help=(
+                         "Save a full diagnostics HDF5 file alongside the NIfTI "
+                         "parameter maps.  Includes convergence, R², residuals, "
+                         "covariance, iteration counts, and fit metadata.  "
+                         "Output: <image_stem>_diagnostics.h5"
+                     )),
         click.option("--output", "-o", default=None,
                      type=click.Path(path_type=Path), metavar="DIR",
                      help=("Output directory for parameter maps. "
@@ -74,6 +82,7 @@ def run_pipeline(
     output: Path | None,
     verbose: bool,
     fixed: tuple[str, ...],
+    diagnostics: bool = False,
 ) -> int:
     """Execute the end-to-end fitting pipeline for any Pyneapple CLI command.
 
@@ -85,6 +94,7 @@ def run_pipeline(
     4. Run fitting.
     5. Reconstruct spatial parameter maps.
     6. Save one NIfTI per parameter.
+    7. Optionally save a diagnostics HDF5 file (``--diagnostics``).
 
     Args:
         image: Path to the 4-D DWI NIfTI image.
@@ -94,6 +104,9 @@ def run_pipeline(
         output: Optional output directory (defaults to image parent).
         verbose: Enable DEBUG-level logging when True.
         fixed: Tuple of ``NAME:PATH`` strings for per-pixel fixed parameters.
+        diagnostics: When True, write a ``<image_stem>_diagnostics.h5`` file
+            containing convergence maps, R², residuals, covariance, iteration
+            counts, and fit metadata alongside the NIfTI parameter maps.
 
     Returns:
         int: Exit code: ``0`` on success, ``1`` on user error, ``2`` on
@@ -225,6 +238,21 @@ def run_pipeline(
             logger.info(f"  Saved {param_name} → {out_path}")
 
         logger.info(f"Done. {len(saved)} parameter map(s) written to '{output_dir}'.")
+
+        # ------------------------------------------------------------------
+        # 7. Optionally save full diagnostics HDF5
+        # ------------------------------------------------------------------
+        if diagnostics:
+            if fitter.results_ is not None:
+                diag_path = output_dir / f"{stem}_diagnostics.h5"
+                save_result_to_hdf5(fitter.results_, spatial_shape, diag_path)
+                logger.info(f"  Diagnostics → {diag_path}")
+            else:
+                logger.warning(
+                    "--diagnostics requested but fitter.results_ is None; "
+                    "skipping HDF5 export."
+                )
+
         return 0
 
     except FileNotFoundError as exc:

--- a/src/pyneapple/cli/ideal.py
+++ b/src/pyneapple/cli/ideal.py
@@ -45,6 +45,7 @@ def ideal(
     output: Path | None,
     verbose: bool,
     fixed: tuple[str, ...],
+    diagnostics: bool,
     seg: Path | None,
 ) -> None:
     """IDEAL iterative multi-resolution fitting.
@@ -61,5 +62,6 @@ def ideal(
             output=output,
             verbose=verbose,
             fixed=fixed,
+            diagnostics=diagnostics,
         )
     )

--- a/src/pyneapple/cli/pixelwise.py
+++ b/src/pyneapple/cli/pixelwise.py
@@ -30,6 +30,7 @@ def pixelwise(
     output: Path | None,
     verbose: bool,
     fixed: tuple[str, ...],
+    diagnostics: bool,
     seg: Path | None,
 ) -> None:
     """Fit each voxel independently.
@@ -46,5 +47,6 @@ def pixelwise(
             output=output,
             verbose=verbose,
             fixed=fixed,
+            diagnostics=diagnostics,
         )
     )

--- a/src/pyneapple/cli/segmentationwise.py
+++ b/src/pyneapple/cli/segmentationwise.py
@@ -31,6 +31,7 @@ def segmented(
     output: Path | None,
     verbose: bool,
     fixed: tuple[str, ...],
+    diagnostics: bool,
     seg: Path,
 ) -> None:
     """Fit the mean signal per labelled ROI (--seg required).
@@ -47,5 +48,6 @@ def segmented(
             output=output,
             verbose=verbose,
             fixed=fixed,
+            diagnostics=diagnostics,
         )
     )

--- a/src/pyneapple/fitters/base.py
+++ b/src/pyneapple/fitters/base.py
@@ -194,6 +194,13 @@ class BaseFitter(ABC):
     ) -> FitResult:
         """Build a :class:`~pyneapple.result.FitResult` from the solver state.
 
+        Delegates solver-level fields (``params``, ``success``,
+        ``covariance``, ``residuals``, ``n_iterations``, ``messages``,
+        ``n_pixels``, ``solver_name``, ``model_name``) to
+        :attr:`~pyneapple.solvers.base.BaseSolver.result_` and overlays
+        the fitter-specific fields (``r_squared``, ``fit_time``,
+        ``image_shape``, ``pixel_indices``).
+
         Should be called immediately after ``solver.fit()`` completes,
         before any state is modified.
 
@@ -208,69 +215,29 @@ class BaseFitter(ABC):
         Returns:
             Populated :class:`~pyneapple.result.FitResult`.
         """
-        prs = self.solver.pixel_results_
-        n_pixels = len(prs)
-
-        # --- success ---
-        success = np.array([pr.success for pr in prs], dtype=bool)
-
-        # --- n_iterations (None when all are None) ---
-        iters = [pr.n_iterations for pr in prs]
-        if any(it is not None for it in iters):
-            n_iterations: np.ndarray | None = np.array(
-                [it if it is not None else -1 for it in iters], dtype=np.intp
+        base = self.solver.result_
+        if base is None:
+            raise RuntimeError(
+                "solver.fit() must be called before _assemble_fit_result(). "
+                "solver.result_ is None."
             )
-        else:
-            n_iterations = None
-
-        # --- messages (None when all are None) ---
-        msgs = [pr.message for pr in prs]
-        messages: list[str | None] | None = (
-            msgs if any(m is not None for m in msgs) else None
-        )
-
-        # --- covariance (None for NNLS which has no covariance) ---
-        covs = [pr.covariance for pr in prs]
-        if any(c is not None for c in covs):
-            n_params = prs[0].params.shape[0]
-            covariance: np.ndarray | None = np.array(
-                [
-                    c if c is not None else np.full((n_params, n_params), np.nan)
-                    for c in covs
-                ]
-            )
-        else:
-            covariance = None
-
-        # --- residuals ---
-        residuals_list = [pr.residual for pr in prs]
-        if any(r is not None for r in residuals_list):
-            residuals: np.ndarray | None = np.array(
-                [r if r is not None else np.nan for r in residuals_list],
-                dtype=np.float64,
-            )
-        else:
-            residuals = None
-
-        # --- R² ---
-        r_squared = self._compute_r_squared(xdata, pixel_signals)
 
         return FitResult(
-            params=dict(self.solver.params_),
-            success=success,
-            n_iterations=n_iterations,
-            messages=messages,
-            covariance=covariance,
-            residuals=residuals,
-            r_squared=r_squared,
+            params=base.params,
+            success=base.success,
+            n_iterations=base.n_iterations,
+            messages=base.messages,
+            covariance=base.covariance,
+            residuals=base.residuals,
+            r_squared=self._compute_r_squared(xdata, pixel_signals),
             fit_time=fit_time,
             image_shape=self.image_shape,
-            pixel_indices=pixel_indices
-            if pixel_indices is not None
-            else self.pixel_indices,
-            n_pixels=n_pixels,
-            solver_name=self.solver.__class__.__name__,
-            model_name=self.solver.model.__class__.__name__,
+            pixel_indices=(
+                pixel_indices if pixel_indices is not None else self.pixel_indices
+            ),
+            n_pixels=base.n_pixels,
+            solver_name=base.solver_name,
+            model_name=base.model_name,
         )
 
     # ------------------------------------------------------------------

--- a/src/pyneapple/io/__init__.py
+++ b/src/pyneapple/io/__init__.py
@@ -22,7 +22,7 @@ from .bvalue import (
     save_bvalues,
 )
 from .toml import load_config, FittingConfig
-from .hdf5 import save_to_hdf5, load_from_hdf5, save_params_to_hdf5
+from .hdf5 import save_to_hdf5, load_from_hdf5, save_params_to_hdf5, save_result_to_hdf5
 from .excel import save_params_to_excel, save_spectrum_to_excel
 
 
@@ -46,6 +46,7 @@ __all__ = [
     "save_to_hdf5",
     "load_from_hdf5",
     "save_params_to_hdf5",
+    "save_result_to_hdf5",
     # Excel utilities
     "save_params_to_excel",
     "save_spectrum_to_excel",

--- a/src/pyneapple/io/hdf5.py
+++ b/src/pyneapple/io/hdf5.py
@@ -23,6 +23,8 @@ Functions:
     load_from_hdf5: Load HDF5 file to dictionary
     dict_to_hdf5: Recursively write dictionary to HDF5 group
     hdf5_to_dict: Recursively read HDF5 group to dictionary
+    save_params_to_hdf5: Save fitted parameter maps to HDF5
+    save_result_to_hdf5: Save a complete FitResult (params + diagnostics + metadata) to HDF5
 
 Example:
     >>> from pathlib import Path
@@ -54,6 +56,8 @@ import h5py
 import numpy as np
 
 from loguru import logger
+
+from ..result import FitResult
 
 # --- Export
 
@@ -321,3 +325,119 @@ def save_params_to_hdf5(
     file_path.parent.mkdir(parents=True, exist_ok=True)
     save_to_hdf5(data, file_path)
     logger.info(f"Saved parameter maps to: {file_path}")
+
+
+def save_result_to_hdf5(
+    result: FitResult,
+    spatial_shape: tuple[int, ...],
+    file_path: Path | str,
+) -> None:
+    """Save a complete :class:`~pyneapple.result.FitResult` to an HDF5 file.
+
+    Writes three top-level groups:
+
+    * ``params/`` — one spatially-reconstructed 3-D array per fitted parameter.
+    * ``diagnostics/`` — per-pixel quality metrics reconstructed to spatial
+      volumes where possible:
+
+      - ``success`` — float32 convergence map (1 = converged, 0 = not).
+      - ``r_squared`` — per-pixel R² map.
+      - ``residuals`` — per-pixel residual-norm map.
+      - ``n_iterations`` — per-pixel iteration-count map.
+      - ``covariance`` — flat ``(n_pixels, n_params, n_params)`` tensor
+        (not reconstructed spatially due to its 3-D nature per pixel).
+
+    * ``metadata/`` — scalar provenance fields:
+
+      - ``fit_time``, ``solver_name``, ``model_name``, ``n_pixels``,
+        ``convergence_rate``, ``mean_r_squared``, ``spatial_shape``,
+        ``pixel_indices``, ``image_shape`` (when available).
+
+    Fields that are ``None`` in the result are silently omitted.
+
+    Args:
+        result: The :class:`~pyneapple.result.FitResult` returned by a fitter.
+        spatial_shape: 3-D spatial shape ``(X, Y, Z)`` of the original image.
+        file_path: Output ``.h5`` path.  Parent directories are created if
+            needed.
+
+    Raises:
+        ValueError: If ``result.params`` is empty.
+
+    Examples:
+        >>> save_result_to_hdf5(fitter.results_, image_data.shape[:3],
+        ...                     "results_diagnostics.h5")
+    """
+    from .nifti import reconstruct_maps
+
+    if not result.params:
+        raise ValueError("FitResult.params is empty — nothing to export.")
+
+    pixel_indices = result.pixel_indices
+
+    # ------------------------------------------------------------------
+    # Helper: scatter a flat per-pixel array back to a spatial volume
+    # ------------------------------------------------------------------
+    def _to_spatial(arr: np.ndarray, key: str, dtype=np.float32) -> np.ndarray:
+        arr = arr.astype(dtype)
+        if pixel_indices is not None:
+            return reconstruct_maps({key: arr}, pixel_indices, spatial_shape)[key]
+        return arr
+
+    # ------------------------------------------------------------------
+    # params/ — reconstructed spatial maps
+    # ------------------------------------------------------------------
+    if pixel_indices is not None:
+        param_maps = reconstruct_maps(result.params, pixel_indices, spatial_shape)
+    else:
+        param_maps = dict(result.params)
+
+    data: dict[str, Any] = {"params": param_maps}
+
+    # ------------------------------------------------------------------
+    # diagnostics/ — per-pixel quality metrics
+    # ------------------------------------------------------------------
+    diag: dict[str, Any] = {}
+
+    if result.success is not None:
+        diag["success"] = _to_spatial(result.success, "success", np.float32)
+    if result.r_squared is not None:
+        diag["r_squared"] = _to_spatial(result.r_squared, "r_squared", np.float32)
+    if result.residuals is not None:
+        diag["residuals"] = _to_spatial(result.residuals, "residuals", np.float32)
+    if result.n_iterations is not None:
+        diag["n_iterations"] = _to_spatial(
+            result.n_iterations, "n_iterations", np.float32
+        )
+    if result.covariance is not None:
+        # Stored flat: (n_pixels, n_params, n_params) — spatial reconstruction
+        # is non-trivial for a 3-D per-pixel tensor.
+        diag["covariance"] = result.covariance.astype(np.float32)
+
+    if diag:
+        data["diagnostics"] = diag
+
+    # ------------------------------------------------------------------
+    # metadata/ — scalars and provenance
+    # ------------------------------------------------------------------
+    meta: dict[str, Any] = {
+        "fit_time": result.fit_time,
+        "solver_name": result.solver_name,
+        "model_name": result.model_name,
+        "n_pixels": result.n_pixels,
+        "convergence_rate": result.convergence_rate,
+        "spatial_shape": np.array(spatial_shape, dtype=np.int32),
+    }
+    if result.mean_r_squared is not None:
+        meta["mean_r_squared"] = result.mean_r_squared
+    if pixel_indices is not None:
+        meta["pixel_indices"] = np.array(pixel_indices, dtype=np.int32)
+    if result.image_shape is not None:
+        meta["image_shape"] = np.array(result.image_shape, dtype=np.int32)
+
+    data["metadata"] = meta
+
+    file_path = Path(file_path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    save_to_hdf5(data, file_path)
+    logger.info(f"Saved FitResult diagnostics to: {file_path}")

--- a/src/pyneapple/solvers/__init__.py
+++ b/src/pyneapple/solvers/__init__.py
@@ -4,6 +4,7 @@ from .base import BaseSolver
 from .curvefit import CurveFitSolver
 from .constrained_curvefit import ConstrainedCurveFitSolver
 from .nnls_solver import NNLSSolver
+from ..result import FitResult
 
 _REGISTRY: dict[str, type] = {
     "curvefit": CurveFitSolver,
@@ -39,5 +40,6 @@ __all__ = [
     "CurveFitSolver",
     "ConstrainedCurveFitSolver",
     "NNLSSolver",
+    "FitResult",
     "get_solver",
 ]

--- a/src/pyneapple/solvers/base.py
+++ b/src/pyneapple/solvers/base.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import numpy as np
 from loguru import logger
+
+from ..result import FitResult
 
 
 @dataclass
@@ -88,3 +90,93 @@ class BaseSolver(ABC):
         self.diagnostics_ = {}
         self.params_ = {}
         self.pixel_results_ = []
+
+    # ------------------------------------------------------------------
+    # Solver-level FitResult
+    # ------------------------------------------------------------------
+
+    @property
+    def result_(self) -> FitResult | None:
+        """Partial :class:`~pyneapple.result.FitResult` assembled from per-pixel results.
+
+        Available immediately after :meth:`fit` returns.  Contains all
+        solver-level diagnostic fields (``params``, ``success``,
+        ``covariance``, ``residuals``, ``n_iterations``, ``messages``,
+        ``n_pixels``, ``solver_name``, ``model_name``) but **not** the
+        fitter-specific fields (``r_squared``, ``fit_time``,
+        ``image_shape``, ``pixel_indices``), which are added by the
+        fitter's ``_assemble_fit_result()``.
+
+        Returns:
+            A :class:`~pyneapple.result.FitResult` if :meth:`fit` has
+            been called, otherwise ``None``.
+        """
+        if not self.pixel_results_:
+            return None
+        return self._build_result()
+
+    def _build_result(self) -> FitResult:
+        """Assemble a partial :class:`~pyneapple.result.FitResult` from ``pixel_results_``.
+
+        Called by :attr:`result_` every time the property is accessed
+        (no internal caching — the result is always fresh).
+
+        Returns:
+            A :class:`~pyneapple.result.FitResult` with solver-level
+            fields populated.
+        """
+        prs = self.pixel_results_
+        n_pixels = len(prs)
+
+        # --- success ---
+        success = np.array([pr.success for pr in prs], dtype=bool)
+
+        # --- n_iterations (None when all are None) ---
+        iters = [pr.n_iterations for pr in prs]
+        if any(it is not None for it in iters):
+            n_iterations: np.ndarray | None = np.array(
+                [it if it is not None else -1 for it in iters], dtype=np.intp
+            )
+        else:
+            n_iterations = None
+
+        # --- messages (None when all are None) ---
+        msgs = [pr.message for pr in prs]
+        messages: list[str | None] | None = (
+            msgs if any(m is not None for m in msgs) else None
+        )
+
+        # --- covariance (None for NNLS which has no covariance) ---
+        covs = [pr.covariance for pr in prs]
+        if any(c is not None for c in covs):
+            n_params = prs[0].params.shape[0]
+            covariance: np.ndarray | None = np.array(
+                [
+                    c if c is not None else np.full((n_params, n_params), np.nan)
+                    for c in covs
+                ]
+            )
+        else:
+            covariance = None
+
+        # --- residuals (None when all are None) ---
+        residuals_list = [pr.residual for pr in prs]
+        if any(r is not None for r in residuals_list):
+            residuals: np.ndarray | None = np.array(
+                [r if r is not None else np.nan for r in residuals_list],
+                dtype=np.float64,
+            )
+        else:
+            residuals = None
+
+        return FitResult(
+            params=dict(self.params_),
+            success=success,
+            n_iterations=n_iterations,
+            messages=messages,
+            covariance=covariance,
+            residuals=residuals,
+            n_pixels=n_pixels,
+            solver_name=self.__class__.__name__,
+            model_name=self.model.__class__.__name__,
+        )

--- a/tests/test_cli_pixelwise.py
+++ b/tests/test_cli_pixelwise.py
@@ -830,3 +830,130 @@ class TestPixelwiseFixed:
             ],
         )
         assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# --diagnostics flag
+# ---------------------------------------------------------------------------
+
+
+class TestPixelwiseDiagnostics:
+    """Tests for the --diagnostics / -d flag that writes a full HDF5 result file."""
+
+    @pytest.mark.unit
+    def test_diagnostics_flag_accepted(self, tmp_path):
+        """--diagnostics is recognised as a valid option and exits with 0."""
+        img = _write_nifti(tmp_path / "dwi.nii.gz", _make_dwi())
+        bval = _write_bval(tmp_path / "b.bval")
+        cfg = _write_monoexp_config(tmp_path / "cfg.toml")
+        result = runner.invoke(
+            pixelwise,
+            ["-i", str(img), "-b", str(bval), "-c", str(cfg), "--diagnostics"],
+        )
+        assert result.exit_code == 0
+
+    @pytest.mark.unit
+    def test_diagnostics_short_flag_accepted(self, tmp_path):
+        """Short flag -d is recognised as alias for --diagnostics."""
+        img = _write_nifti(tmp_path / "dwi.nii.gz", _make_dwi())
+        bval = _write_bval(tmp_path / "b.bval")
+        cfg = _write_monoexp_config(tmp_path / "cfg.toml")
+        result = runner.invoke(
+            pixelwise,
+            ["-i", str(img), "-b", str(bval), "-c", str(cfg), "-d"],
+        )
+        assert result.exit_code == 0
+
+    @pytest.mark.integration
+    def test_diagnostics_creates_h5_file(self, tmp_path):
+        """--diagnostics produces a <stem>_diagnostics.h5 alongside NIfTI maps."""
+        img = _write_nifti(tmp_path / "dwi.nii.gz", _make_dwi())
+        bval = _write_bval(tmp_path / "b.bval")
+        cfg = _write_monoexp_config(tmp_path / "cfg.toml")
+        runner.invoke(
+            pixelwise,
+            ["-i", str(img), "-b", str(bval), "-c", str(cfg), "--diagnostics"],
+        )
+        assert (tmp_path / "dwi_diagnostics.h5").exists()
+
+    @pytest.mark.integration
+    def test_without_diagnostics_no_h5_file(self, tmp_path):
+        """Without --diagnostics, no HDF5 file is written to the output directory."""
+        img = _write_nifti(tmp_path / "dwi.nii.gz", _make_dwi())
+        bval = _write_bval(tmp_path / "b.bval")
+        cfg = _write_monoexp_config(tmp_path / "cfg.toml")
+        runner.invoke(
+            pixelwise,
+            ["-i", str(img), "-b", str(bval), "-c", str(cfg)],
+        )
+        h5_files = list(tmp_path.glob("*.h5"))
+        assert len(h5_files) == 0, "No HDF5 file should be written without --diagnostics"
+
+    @pytest.mark.integration
+    def test_diagnostics_h5_has_expected_groups(self, tmp_path):
+        """The diagnostics HDF5 contains 'params', 'diagnostics', and 'metadata'."""
+        from pyneapple.io import load_from_hdf5
+
+        img = _write_nifti(tmp_path / "dwi.nii.gz", _make_dwi())
+        bval = _write_bval(tmp_path / "b.bval")
+        cfg = _write_monoexp_config(tmp_path / "cfg.toml")
+        runner.invoke(
+            pixelwise,
+            ["-i", str(img), "-b", str(bval), "-c", str(cfg), "--diagnostics"],
+        )
+        loaded = load_from_hdf5(tmp_path / "dwi_diagnostics.h5")
+        assert "params" in loaded
+        assert "diagnostics" in loaded
+        assert "metadata" in loaded
+
+    @pytest.mark.integration
+    def test_diagnostics_h5_records_model_and_solver(self, tmp_path):
+        """Diagnostics metadata stores the correct model_name and solver_name."""
+        from pyneapple.io import load_from_hdf5
+
+        img = _write_nifti(tmp_path / "dwi.nii.gz", _make_dwi())
+        bval = _write_bval(tmp_path / "b.bval")
+        cfg = _write_monoexp_config(tmp_path / "cfg.toml")
+        runner.invoke(
+            pixelwise,
+            ["-i", str(img), "-b", str(bval), "-c", str(cfg), "--diagnostics"],
+        )
+        loaded = load_from_hdf5(tmp_path / "dwi_diagnostics.h5")
+        assert loaded["metadata"]["model_name"] == "MonoExpModel"
+        assert loaded["metadata"]["solver_name"] == "CurveFitSolver"
+
+    @pytest.mark.integration
+    def test_diagnostics_h5_params_have_correct_shape(self, tmp_path):
+        """Diagnostics HDF5 params have the correct 3-D spatial shape."""
+        from pyneapple.io import load_from_hdf5
+
+        n_x, n_y, n_z = 4, 4, 1
+        img = _write_nifti(
+            tmp_path / "dwi.nii.gz", _make_dwi(n_x=n_x, n_y=n_y, n_z=n_z)
+        )
+        bval = _write_bval(tmp_path / "b.bval")
+        cfg = _write_monoexp_config(tmp_path / "cfg.toml")
+        runner.invoke(
+            pixelwise,
+            ["-i", str(img), "-b", str(bval), "-c", str(cfg), "--diagnostics"],
+        )
+        loaded = load_from_hdf5(tmp_path / "dwi_diagnostics.h5")
+        spatial_shape = (n_x, n_y, n_z)
+        for param_vol in loaded["params"].values():
+            assert param_vol.shape == spatial_shape
+
+    @pytest.mark.integration
+    def test_diagnostics_h5_output_in_custom_dir(self, tmp_path):
+        """--diagnostics respects --output and writes the HDF5 to the custom directory."""
+        img = _write_nifti(tmp_path / "dwi.nii.gz", _make_dwi())
+        bval = _write_bval(tmp_path / "b.bval")
+        cfg = _write_monoexp_config(tmp_path / "cfg.toml")
+        out_dir = tmp_path / "results"
+        runner.invoke(
+            pixelwise,
+            [
+                "-i", str(img), "-b", str(bval), "-c", str(cfg),
+                "-o", str(out_dir), "--diagnostics",
+            ],
+        )
+        assert (out_dir / "dwi_diagnostics.h5").exists()

--- a/tests/test_io_hdf5.py
+++ b/tests/test_io_hdf5.py
@@ -8,6 +8,7 @@ Covers:
 - Path object serialisation
 - List vs array distinction
 - String (bytes) decoding
+- save_result_to_hdf5: full FitResult serialisation
 """
 
 from __future__ import annotations
@@ -21,8 +22,10 @@ from pyneapple.io.hdf5 import (
     load_from_hdf5,
     save_to_hdf5,
     save_params_to_hdf5,
+    save_result_to_hdf5,
     _DEFAULT_GZIP_LEVEL,
 )
+from pyneapple.result import FitResult
 
 
 # ---------------------------------------------------------------------------
@@ -355,3 +358,227 @@ class TestSaveParamsToHdf5:
         out = tmp_path / "nested" / "dir" / "params.h5"
         save_params_to_hdf5(fitted_params, pixel_indices, spatial_shape, out)
         assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# TestSaveResultToHdf5
+# ---------------------------------------------------------------------------
+
+
+class TestSaveResultToHdf5:
+    """Tests for the save_result_to_hdf5 full-result serialisation function."""
+
+    @pytest.fixture
+    def full_result(self):
+        """FitResult with all diagnostic fields populated for a 4×4×1 image."""
+        rng = np.random.default_rng(0)
+        n_pixels = 16
+        pixel_indices = [(x, y, 0) for x in range(4) for y in range(4)]
+        params = {
+            "S0": rng.uniform(800, 1200, n_pixels).astype(np.float32),
+            "D": rng.uniform(0.0005, 0.003, n_pixels).astype(np.float32),
+        }
+        result = FitResult(
+            params=params,
+            success=np.ones(n_pixels, dtype=bool),
+            r_squared=rng.uniform(0.95, 1.0, n_pixels).astype(np.float32),
+            residuals=rng.uniform(0.0, 0.1, n_pixels).astype(np.float32),
+            n_iterations=np.full(n_pixels, 15, dtype=np.int32),
+            covariance=np.zeros((n_pixels, 2, 2), dtype=np.float32),
+            fit_time=1.23,
+            n_pixels=n_pixels,
+            solver_name="CurveFitSolver",
+            model_name="MonoExpModel",
+            pixel_indices=pixel_indices,
+            image_shape=(4, 4, 1, 8),
+        )
+        return result, (4, 4, 1)
+
+    @pytest.fixture
+    def minimal_result(self):
+        """Minimal FitResult with only required fields; all optional fields are None."""
+        n_pixels = 4
+        pixel_indices = [(i, 0, 0) for i in range(n_pixels)]
+        params = {"D": np.array([0.001, 0.002, 0.001, 0.002], dtype=np.float32)}
+        result = FitResult(
+            params=params,
+            success=np.ones(n_pixels, dtype=bool),
+            n_pixels=n_pixels,
+            pixel_indices=pixel_indices,
+        )
+        return result, (4, 1, 1)
+
+    # --- File system ---
+
+    def test_file_is_created(self, tmp_path, full_result):
+        """save_result_to_hdf5 writes an HDF5 file to disk."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        assert out.exists()
+
+    def test_parent_dir_created(self, tmp_path, full_result):
+        """save_result_to_hdf5 creates missing parent directories."""
+        result, spatial_shape = full_result
+        out = tmp_path / "nested" / "subdir" / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        assert out.exists()
+
+    def test_string_filepath_accepted(self, tmp_path, full_result):
+        """save_result_to_hdf5 accepts a str path as well as pathlib.Path."""
+        result, spatial_shape = full_result
+        out = str(tmp_path / "result.h5")
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        assert "params" in loaded
+
+    def test_raises_on_empty_params(self, tmp_path):
+        """save_result_to_hdf5 raises ValueError when FitResult.params is empty."""
+        result = FitResult(params={}, success=np.array([True]), n_pixels=1)
+        with pytest.raises(ValueError, match="empty"):
+            save_result_to_hdf5(result, (1, 1, 1), tmp_path / "out.h5")
+
+    # --- Top-level structure ---
+
+    def test_top_level_groups_present(self, tmp_path, full_result):
+        """Loaded file contains 'params', 'diagnostics', and 'metadata' groups."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        assert "params" in loaded
+        assert "diagnostics" in loaded
+        assert "metadata" in loaded
+
+    # --- params/ group ---
+
+    def test_params_have_correct_spatial_shape(self, tmp_path, full_result):
+        """Each entry in 'params/' has the correct 3-D spatial shape."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        assert loaded["params"]["S0"].shape == spatial_shape
+        assert loaded["params"]["D"].shape == spatial_shape
+
+    def test_params_values_at_correct_voxel(self, tmp_path, full_result):
+        """S0 values are scattered to the correct spatial positions."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        for i, (x, y, z) in enumerate(result.pixel_indices):
+            np.testing.assert_allclose(
+                loaded["params"]["S0"][x, y, z],
+                result.params["S0"][i],
+                rtol=1e-5,
+            )
+
+    # --- diagnostics/ group ---
+
+    def test_success_map_has_correct_shape(self, tmp_path, full_result):
+        """Diagnostics 'success' map is reconstructed to the correct spatial shape."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        assert loaded["diagnostics"]["success"].shape == spatial_shape
+
+    def test_r_squared_map_has_correct_shape(self, tmp_path, full_result):
+        """Diagnostics 'r_squared' map is reconstructed to the correct spatial shape."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        assert loaded["diagnostics"]["r_squared"].shape == spatial_shape
+
+    def test_residuals_map_has_correct_shape(self, tmp_path, full_result):
+        """Diagnostics 'residuals' map is reconstructed to the correct spatial shape."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        assert loaded["diagnostics"]["residuals"].shape == spatial_shape
+
+    def test_n_iterations_map_has_correct_shape(self, tmp_path, full_result):
+        """Diagnostics 'n_iterations' map is reconstructed to the correct spatial shape."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        assert loaded["diagnostics"]["n_iterations"].shape == spatial_shape
+
+    def test_covariance_stored_flat(self, tmp_path, full_result):
+        """Covariance is stored flat as (n_pixels, n_params, n_params), not spatially."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        assert loaded["diagnostics"]["covariance"].shape == (16, 2, 2)
+
+    def test_optional_diagnostics_absent_when_none(self, tmp_path, minimal_result):
+        """Only 'success' is in diagnostics when all optional diagnostic fields are None."""
+        result, spatial_shape = minimal_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        diag = loaded.get("diagnostics", {})
+        assert "success" in diag, "success should always be written"
+        assert "r_squared" not in diag
+        assert "residuals" not in diag
+        assert "n_iterations" not in diag
+        assert "covariance" not in diag
+
+    # --- metadata/ group ---
+
+    def test_metadata_fit_time(self, tmp_path, full_result):
+        """Metadata stores the correct fit_time value."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        assert loaded["metadata"]["fit_time"] == pytest.approx(1.23)
+
+    def test_metadata_solver_name(self, tmp_path, full_result):
+        """Metadata stores the correct solver_name string."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        assert loaded["metadata"]["solver_name"] == "CurveFitSolver"
+
+    def test_metadata_model_name(self, tmp_path, full_result):
+        """Metadata stores the correct model_name string."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        assert loaded["metadata"]["model_name"] == "MonoExpModel"
+
+    def test_metadata_convergence_rate_all_converged(self, tmp_path, full_result):
+        """Metadata convergence_rate is 1.0 when all pixels converged."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        assert loaded["metadata"]["convergence_rate"] == pytest.approx(1.0)
+
+    def test_metadata_pixel_indices_shape(self, tmp_path, full_result):
+        """Metadata pixel_indices is an (n_pixels, 3) int32 array."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        pix = loaded["metadata"]["pixel_indices"]
+        assert pix.shape == (16, 3)
+        assert pix.dtype == np.int32
+
+    def test_metadata_image_shape_stored(self, tmp_path, full_result):
+        """Metadata image_shape matches the original 4-D image shape."""
+        result, spatial_shape = full_result
+        out = tmp_path / "result.h5"
+        save_result_to_hdf5(result, spatial_shape, out)
+        loaded = load_from_hdf5(out)
+        np.testing.assert_array_equal(
+            loaded["metadata"]["image_shape"], np.array([4, 4, 1, 8], dtype=np.int32)
+        )

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -10,7 +10,6 @@ from pyneapple.solvers.base import _PixelFitResult
 from pyneapple.fitters import PixelWiseFitter
 from test_toolbox import B_VALUES, make_monoexp_image, make_monoexp_solver
 
-
 # ---------------------------------------------------------------------------
 # _PixelFitResult unit tests
 # ---------------------------------------------------------------------------
@@ -339,3 +338,92 @@ class TestFitResultIntegration:
         fitter = PixelWiseFitter(solver=solver)
         returned = fitter.fit(b_values, monoexp_image)
         assert returned is fitter
+
+
+# ---------------------------------------------------------------------------
+# Integration: failure detection in fitter.results_
+# ---------------------------------------------------------------------------
+
+
+def _patch_second_pixel_fail(solver, mocker):
+    """Patch ``solver._fit_single_pixel`` so the 2nd call returns ``success=False``.
+
+    All other calls delegate to the real implementation.
+    """
+    original = solver._fit_single_pixel
+    call_count = {"n": 0}
+
+    def selective_fail(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            # p0 is the 3rd positional arg (xdata, ydata, p0, bounds, ...)
+            p0 = args[2] if len(args) > 2 else np.array([900.0, 0.0012])
+            n = len(p0)
+            return _PixelFitResult(
+                params=p0,
+                covariance=np.full((n, n), np.nan),
+                success=False,
+                message="Mocked failure for pixel 1",
+            )
+        return original(*args, **kwargs)
+
+    mocker.patch.object(solver, "_fit_single_pixel", side_effect=selective_fail)
+
+
+class TestFitResultFailureDetection:
+    """End-to-end failure detection: fitter.results_.success reflects pixel-level failures."""
+
+    def test_failed_pixel_marked_in_fitter_results(
+        self, b_values, monoexp_image, mocker
+    ):
+        """When pixel 1 fails, fitter.results_.success[1] is False."""
+        solver = make_monoexp_solver()
+        fitter = PixelWiseFitter(solver=solver)
+        _patch_second_pixel_fail(solver, mocker)
+        fitter.fit(b_values, monoexp_image)
+        assert not fitter.results_.success[1], (
+            "Pixel 1 was mocked to fail but results_.success[1] is True"
+        )
+
+    def test_other_pixels_still_converge(self, b_values, monoexp_image, mocker):
+        """All pixels except the mocked-failure pixel report success=True."""
+        solver = make_monoexp_solver()
+        fitter = PixelWiseFitter(solver=solver)
+        _patch_second_pixel_fail(solver, mocker)
+        fitter.fit(b_values, monoexp_image)
+        success = fitter.results_.success
+        n_pixels = int(np.prod(monoexp_image.shape[:-1]))
+        for i in range(n_pixels):
+            if i != 1:
+                assert success[i], f"Pixel {i} should have converged"
+
+    def test_n_converged_reflects_failure(self, b_values, monoexp_image, mocker):
+        """n_converged is n_pixels - 1 when exactly one pixel fails."""
+        solver = make_monoexp_solver()
+        fitter = PixelWiseFitter(solver=solver)
+        n_pixels = int(np.prod(monoexp_image.shape[:-1]))
+        _patch_second_pixel_fail(solver, mocker)
+        fitter.fit(b_values, monoexp_image)
+        assert fitter.results_.n_converged == n_pixels - 1
+
+    def test_convergence_rate_reflects_failure(self, b_values, monoexp_image, mocker):
+        """convergence_rate is (n-1)/n when exactly one pixel fails."""
+        solver = make_monoexp_solver()
+        fitter = PixelWiseFitter(solver=solver)
+        n_pixels = int(np.prod(monoexp_image.shape[:-1]))
+        _patch_second_pixel_fail(solver, mocker)
+        fitter.fit(b_values, monoexp_image)
+        expected = (n_pixels - 1) / n_pixels
+        assert fitter.results_.convergence_rate == pytest.approx(expected)
+
+    def test_failed_pixel_covariance_is_nan(self, b_values, monoexp_image, mocker):
+        """Failed pixel has NaN covariance in fitter.results_.covariance[1]."""
+        solver = make_monoexp_solver()
+        fitter = PixelWiseFitter(solver=solver)
+        _patch_second_pixel_fail(solver, mocker)
+        fitter.fit(b_values, monoexp_image)
+        cov = fitter.results_.covariance
+        assert cov is not None, "Covariance should be present for CurveFitSolver"
+        assert np.all(np.isnan(cov[1])), (
+            f"Failed pixel covariance should be NaN, got {cov[1]}"
+        )

--- a/tests/test_solver_constrained_curvefit.py
+++ b/tests/test_solver_constrained_curvefit.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from pyneapple.models import BiExpModel, TriExpModel
-from pyneapple.solvers import ConstrainedCurveFitSolver
+from pyneapple.solvers import ConstrainedCurveFitSolver, FitResult
 
 
 # ---------------------------------------------------------------------------
@@ -717,3 +717,126 @@ class TestConstrainedCurveFitSolverFixedParams:
             assert (
                 frac_sum <= 1.0 + 1e-10
             ), f"Voxel {i}: fraction sum {frac_sum} exceeds 1"
+
+
+# ---------------------------------------------------------------------------
+# TestConstrainedCurveFitSolverResultProperty
+# ---------------------------------------------------------------------------
+
+
+class TestConstrainedCurveFitSolverResultProperty:
+    """Tests for the solver.result_ property (partial FitResult) on ConstrainedCurveFitSolver."""
+
+    def test_result_is_none_before_fit(self, constrained_triexp_solver):
+        """result_ is None before fit() is called."""
+        assert constrained_triexp_solver.result_ is None
+
+    def test_result_is_fit_result_after_fit(
+        self, constrained_triexp_solver, b_values, synthetic_triexp_reduced
+    ):
+        """result_ is a FitResult instance after fit()."""
+        signal, _ = synthetic_triexp_reduced
+        constrained_triexp_solver.fit(b_values, signal)
+        assert isinstance(constrained_triexp_solver.result_, FitResult)
+
+    def test_result_success_all_true_on_good_data(
+        self, constrained_triexp_solver, b_values, synthetic_triexp_reduced
+    ):
+        """result_.success is all-True for noise-free data."""
+        signal, _ = synthetic_triexp_reduced
+        constrained_triexp_solver.fit(b_values, signal)
+        assert np.all(constrained_triexp_solver.result_.success)
+
+    def test_result_success_false_on_exception(
+        self, constrained_triexp_solver, b_values, synthetic_triexp_reduced, mocker
+    ):
+        """result_.success[0] is False when minimize raises RuntimeError."""
+        signal, _ = synthetic_triexp_reduced
+        mocker.patch(
+            "pyneapple.solvers.constrained_curvefit.minimize",
+            side_effect=RuntimeError("Mocked optimisation failure"),
+        )
+        constrained_triexp_solver.fit(b_values, signal)
+        assert not constrained_triexp_solver.result_.success[0]
+
+    def test_result_n_pixels_single(
+        self, constrained_triexp_solver, b_values, synthetic_triexp_reduced
+    ):
+        """result_.n_pixels is 1 after a single-voxel fit."""
+        signal, _ = synthetic_triexp_reduced
+        constrained_triexp_solver.fit(b_values, signal)
+        assert constrained_triexp_solver.result_.n_pixels == 1
+
+    def test_result_n_pixels_multi(self, constrained_triexp_solver, b_values):
+        """result_.n_pixels equals the number of voxels after a multi-voxel fit."""
+        model = TriExpModel(fit_reduced=True)
+        param_sets = [
+            (0.2, 0.01, 0.3, 0.003, 0.0005),
+            (0.3, 0.008, 0.4, 0.002, 0.0003),
+            (0.15, 0.012, 0.25, 0.004, 0.0007),
+        ]
+        signals = np.array([model.forward(b_values, *ps) for ps in param_sets])
+        constrained_triexp_solver.fit(b_values, signals)
+        assert constrained_triexp_solver.result_.n_pixels == len(param_sets)
+
+    def test_result_solver_and_model_name(
+        self, constrained_triexp_solver, b_values, synthetic_triexp_reduced
+    ):
+        """result_ carries the correct solver_name and model_name."""
+        signal, _ = synthetic_triexp_reduced
+        constrained_triexp_solver.fit(b_values, signal)
+        assert constrained_triexp_solver.result_.solver_name == "ConstrainedCurveFitSolver"
+        assert constrained_triexp_solver.result_.model_name == "TriExpModel"
+
+    def test_result_params_keys_match_model(
+        self, constrained_triexp_solver, b_values, synthetic_triexp_reduced
+    ):
+        """result_.params keys match the model's param_names."""
+        signal, _ = synthetic_triexp_reduced
+        constrained_triexp_solver.fit(b_values, signal)
+        assert set(constrained_triexp_solver.result_.params.keys()) == {
+            "f1", "D1", "f2", "D2", "D3"
+        }
+
+    def test_result_covariance_present(
+        self, constrained_triexp_solver, b_values, synthetic_triexp_reduced
+    ):
+        """result_.covariance is not None for ConstrainedCurveFitSolver (numerical covariance)."""
+        signal, _ = synthetic_triexp_reduced
+        constrained_triexp_solver.fit(b_values, signal)
+        assert constrained_triexp_solver.result_.covariance is not None
+
+    def test_result_r_squared_is_none(
+        self, constrained_triexp_solver, b_values, synthetic_triexp_reduced
+    ):
+        """result_.r_squared is None at solver level (computed by the fitter)."""
+        signal, _ = synthetic_triexp_reduced
+        constrained_triexp_solver.fit(b_values, signal)
+        assert constrained_triexp_solver.result_.r_squared is None
+
+    def test_result_fit_time_is_zero(
+        self, constrained_triexp_solver, b_values, synthetic_triexp_reduced
+    ):
+        """result_.fit_time is 0.0 at solver level (measured by the fitter)."""
+        signal, _ = synthetic_triexp_reduced
+        constrained_triexp_solver.fit(b_values, signal)
+        assert constrained_triexp_solver.result_.fit_time == 0.0
+
+    def test_result_refreshed_after_refit(
+        self, constrained_triexp_solver, b_values, synthetic_triexp_reduced, mocker
+    ):
+        """result_.success reflects the most recent fit, not a stale cached value."""
+        signal, _ = synthetic_triexp_reduced
+        # First fit — should succeed
+        constrained_triexp_solver.fit(b_values, signal)
+        assert np.all(constrained_triexp_solver.result_.success)
+
+        # Second fit — mock failure
+        mocker.patch(
+            "pyneapple.solvers.constrained_curvefit.minimize",
+            side_effect=RuntimeError("Mocked failure on refit"),
+        )
+        constrained_triexp_solver.fit(b_values, signal)
+        assert not constrained_triexp_solver.result_.success[0], (
+            "result_ should reflect the new (failed) fit, not the previous success"
+        )

--- a/tests/test_solver_curvefit.py
+++ b/tests/test_solver_curvefit.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from pyneapple.models import MonoExpModel, BiExpModel
-from pyneapple.solvers import CurveFitSolver
+from pyneapple.solvers import CurveFitSolver, FitResult
 from pyneapple.solvers.base import _PixelFitResult
 
 
@@ -950,3 +950,120 @@ class TestCurveFitSolverFixedParams:
         params = solver.get_params()
         np.testing.assert_allclose(params["S0"], S0_true, rtol=1e-2)
         np.testing.assert_allclose(params["D"], D_true, rtol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# TestCurveFitSolverResultProperty
+# ---------------------------------------------------------------------------
+
+
+class TestCurveFitSolverResultProperty:
+    """Tests for the solver.result_ property (partial FitResult)."""
+
+    def test_result_is_none_before_fit(self, monoexp_solver):
+        """result_ is None before fit() is called."""
+        assert monoexp_solver.result_ is None
+
+    def test_result_is_fit_result_after_fit(
+        self, monoexp_solver, b_values, synthetic_single
+    ):
+        """result_ is a FitResult instance after fit()."""
+        signal, _, _ = synthetic_single
+        monoexp_solver.fit(b_values, signal)
+        assert isinstance(monoexp_solver.result_, FitResult)
+
+    def test_result_success_all_true_on_good_data(
+        self, monoexp_solver, b_values, synthetic_single
+    ):
+        """result_.success is all-True for noise-free data."""
+        signal, _, _ = synthetic_single
+        monoexp_solver.fit(b_values, signal)
+        assert np.all(monoexp_solver.result_.success)
+
+    def test_result_success_false_on_exception(
+        self, monoexp_solver, b_values, synthetic_single, mocker
+    ):
+        """result_.success[0] is False when curve_fit raises RuntimeError."""
+        signal, _, _ = synthetic_single
+        mocker.patch(
+            "pyneapple.solvers.curvefit.curve_fit",
+            side_effect=RuntimeError("Mocked optimisation failure"),
+        )
+        monoexp_solver.fit(b_values, signal)
+        assert not monoexp_solver.result_.success[0]
+
+    def test_result_n_pixels_single(
+        self, monoexp_solver, b_values, synthetic_single
+    ):
+        """result_.n_pixels is 1 after a single-voxel fit."""
+        signal, _, _ = synthetic_single
+        monoexp_solver.fit(b_values, signal)
+        assert monoexp_solver.result_.n_pixels == 1
+
+    def test_result_n_pixels_multi(
+        self, monoexp_solver, b_values, synthetic_multi
+    ):
+        """result_.n_pixels equals the number of voxels after a multi-voxel fit."""
+        signals, param_sets = synthetic_multi
+        monoexp_solver.fit(b_values, signals)
+        assert monoexp_solver.result_.n_pixels == len(param_sets)
+
+    def test_result_solver_and_model_name(
+        self, monoexp_solver, b_values, synthetic_single
+    ):
+        """result_ carries the correct solver_name and model_name."""
+        signal, _, _ = synthetic_single
+        monoexp_solver.fit(b_values, signal)
+        assert monoexp_solver.result_.solver_name == "CurveFitSolver"
+        assert monoexp_solver.result_.model_name == "MonoExpModel"
+
+    def test_result_params_keys_match_model(
+        self, monoexp_solver, b_values, synthetic_single
+    ):
+        """result_.params keys match the model's param_names."""
+        signal, _, _ = synthetic_single
+        monoexp_solver.fit(b_values, signal)
+        assert set(monoexp_solver.result_.params.keys()) == {"S0", "D"}
+
+    def test_result_covariance_present(
+        self, monoexp_solver, b_values, synthetic_single
+    ):
+        """result_.covariance is not None for CurveFitSolver (has analytic covariance)."""
+        signal, _, _ = synthetic_single
+        monoexp_solver.fit(b_values, signal)
+        assert monoexp_solver.result_.covariance is not None
+
+    def test_result_r_squared_is_none(
+        self, monoexp_solver, b_values, synthetic_single
+    ):
+        """result_.r_squared is None at solver level (computed by the fitter)."""
+        signal, _, _ = synthetic_single
+        monoexp_solver.fit(b_values, signal)
+        assert monoexp_solver.result_.r_squared is None
+
+    def test_result_fit_time_is_zero(
+        self, monoexp_solver, b_values, synthetic_single
+    ):
+        """result_.fit_time is 0.0 at solver level (measured by the fitter)."""
+        signal, _, _ = synthetic_single
+        monoexp_solver.fit(b_values, signal)
+        assert monoexp_solver.result_.fit_time == 0.0
+
+    def test_result_refreshed_after_refit(
+        self, monoexp_solver, b_values, synthetic_single, mocker
+    ):
+        """result_.success reflects the most recent fit, not a stale cached value."""
+        signal, _, _ = synthetic_single
+        # First fit — should succeed
+        monoexp_solver.fit(b_values, signal)
+        assert np.all(monoexp_solver.result_.success)
+
+        # Second fit — mock failure
+        mocker.patch(
+            "pyneapple.solvers.curvefit.curve_fit",
+            side_effect=RuntimeError("Mocked failure on refit"),
+        )
+        monoexp_solver.fit(b_values, signal)
+        assert not monoexp_solver.result_.success[0], (
+            "result_ should reflect the new (failed) fit, not the previous success"
+        )

--- a/tests/test_solver_nnls.py
+++ b/tests/test_solver_nnls.py
@@ -6,6 +6,7 @@ import pytest
 from pyneapple.models import NNLSModel
 from pyneapple.solvers.base import _PixelFitResult
 from pyneapple.solvers.nnls_solver import NNLSSolver
+from pyneapple.solvers import FitResult
 
 
 # ---------------------------------------------------------------------------
@@ -740,3 +741,101 @@ class TestNNLSSolverDiagnostics:
         signal, _, _ = synthetic_single
         returned = nnls_solver.fit(b_values, signal)
         assert returned is nnls_solver, "fit() must return self"
+
+
+# ---------------------------------------------------------------------------
+# TestNNLSSolverResultProperty
+# ---------------------------------------------------------------------------
+
+
+class TestNNLSSolverResultProperty:
+    """Tests for the solver.result_ property (partial FitResult) on NNLSSolver."""
+
+    def test_result_is_none_before_fit(self, nnls_solver):
+        """result_ is None before fit() is called."""
+        assert nnls_solver.result_ is None
+
+    def test_result_is_fit_result_after_fit(
+        self, nnls_solver, b_values, synthetic_single
+    ):
+        """result_ is a FitResult instance after fit()."""
+        signal, _, _ = synthetic_single
+        nnls_solver.fit(b_values, signal)
+        assert isinstance(nnls_solver.result_, FitResult)
+
+    def test_result_success_all_true_on_good_data(
+        self, nnls_solver, b_values, synthetic_single
+    ):
+        """result_.success is all-True for normal NNLS fitting."""
+        signal, _, _ = synthetic_single
+        nnls_solver.fit(b_values, signal)
+        assert np.all(nnls_solver.result_.success)
+
+    def test_result_success_false_on_exception(
+        self, nnls_solver, b_values, synthetic_single, mocker
+    ):
+        """result_.success[0] is False when nnls raises RuntimeError."""
+        signal, _, _ = synthetic_single
+        mocker.patch(
+            "pyneapple.solvers.nnls_solver.nnls",
+            side_effect=RuntimeError("Mocked NNLS failure"),
+        )
+        nnls_solver.fit(b_values, signal)
+        assert not nnls_solver.result_.success[0]
+
+    def test_result_n_pixels_single(self, nnls_solver, b_values, synthetic_single):
+        """result_.n_pixels is 1 after a single-voxel fit."""
+        signal, _, _ = synthetic_single
+        nnls_solver.fit(b_values, signal)
+        assert nnls_solver.result_.n_pixels == 1
+
+    def test_result_n_pixels_multi(self, nnls_solver, b_values, synthetic_multi):
+        """result_.n_pixels equals the number of voxels after a multi-voxel fit."""
+        signals, param_sets = synthetic_multi
+        nnls_solver.fit(b_values, signals)
+        assert nnls_solver.result_.n_pixels == len(param_sets)
+
+    def test_result_solver_and_model_name(
+        self, nnls_solver, b_values, synthetic_single
+    ):
+        """result_ carries the correct solver_name and model_name."""
+        signal, _, _ = synthetic_single
+        nnls_solver.fit(b_values, signal)
+        assert nnls_solver.result_.solver_name == "NNLSSolver"
+        assert nnls_solver.result_.model_name == "NNLSModel"
+
+    def test_result_residuals_populated(
+        self, nnls_solver, b_values, synthetic_single
+    ):
+        """result_.residuals is not None for NNLSSolver (NNLS tracks residuals)."""
+        signal, _, _ = synthetic_single
+        nnls_solver.fit(b_values, signal)
+        assert nnls_solver.result_.residuals is not None
+        assert nnls_solver.result_.residuals.shape == (1,)
+
+    def test_result_covariance_is_none(
+        self, nnls_solver, b_values, synthetic_single
+    ):
+        """result_.covariance is None for NNLSSolver (no analytic covariance)."""
+        signal, _, _ = synthetic_single
+        nnls_solver.fit(b_values, signal)
+        assert nnls_solver.result_.covariance is None
+
+    def test_result_refreshed_after_refit(
+        self, nnls_solver, b_values, synthetic_single, mocker
+    ):
+        """result_.success reflects the most recent fit, not a stale cached value."""
+        signal, _, _ = synthetic_single
+        # First fit — should succeed
+        nnls_solver.fit(b_values, signal)
+        assert np.all(nnls_solver.result_.success)
+
+        # Second fit — mock failure
+        mocker.patch(
+            "pyneapple.solvers.nnls_solver.nnls",
+            side_effect=RuntimeError("Mocked failure on refit"),
+        )
+        nnls_solver.fit(b_values, signal)
+        assert not nnls_solver.result_.success[0], (
+            "result_ should reflect the new (failed) fit, not the previous success"
+        )


### PR DESCRIPTION
## Summary

Introduce `FitResult` — a structured dataclass returned by all fitters after fitting — enabling downstream code to distinguish between converged and failed fits, inspect per-pixel diagnostics, and export results to HDF5.

## Changes

### Added

- **`FitResult` dataclass** (`src/pyneapple/result.py`) — public container with fields: `params`, `success`, `covariance`, `residuals`, `r_squared`, `n_iterations`, `messages`, `fit_time`, `image_shape`, `pixel_indices`, `n_pixels`, `solver_name`, `model_name`. Includes convenience properties `n_converged`, `convergence_rate`, `mean_r_squared`. Exported from `pyneapple.FitResult` and `pyneapple.solvers.FitResult`.

- **`_PixelFitResult` internal dataclass** (`src/pyneapple/solvers/base.py`) — per-pixel result with `params`, `covariance`, `success`, `message`, `n_iterations`, `residual`.

- **`BaseSolver.result_` property** — assembles a partial `FitResult` from all per-pixel `_PixelFitResult` entries after `fit()`. Returns `None` before fitting.

- **`BaseFitter._assemble_fit_result()`** — builds the full `FitResult` by combining the solver's partial result (`result_`) with fitter-specific fields (`r_squared`, `fit_time`, `image_shape`, `pixel_indices`). Fitters store this as `self.results_`.

- **Pixel-level failure detection** — `CurveFitSolver`, `NNLSSolver`, and `ConstrainedCurveFitSolver` all catch exceptions in `_fit_single_pixel` and return `_PixelFitResult(success=False, message=str(e), ...)` instead of silently returning initial guesses.

- **`save_result_to_hdf5()`** (`src/pyneapple/io/hdf5.py`) — serialises a complete `FitResult` to HDF5 with `params/`, `diagnostics/`, and `metadata/` groups; spatially reconstructs per-pixel arrays when pixel indices are available.

- **CLI `--diagnostics` flag** — `pyneapple pixelwise --diagnostics` writes a diagnostics HDF5 alongside the standard output.

- **Comprehensive test suite** — `test_result.py` (unit tests for `_PixelFitResult`, `FitResult` construction/properties/export/integration, and failure detection); solver-specific `result_` property tests in `test_solver_curvefit.py`, `test_solver_nnls.py`, `test_solver_constrained_curvefit.py`; HDF5 round-trip tests in `test_io_hdf5.py`; CLI diagnostics tests in `test_cli_pixelwise.py`.

### Breaking Changes

- None. The `FitResult` is additive and backwards-compatible.

### Closes

Closes #205
